### PR TITLE
User can select category for ToDo item

### DIFF
--- a/app/components/CategoryBadge.tsx
+++ b/app/components/CategoryBadge.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+type CategoryBadgeProps = {
+  category: 'home' | 'hobbies' | 'work';
+};
+
+const CategoryBadge: React.FC<CategoryBadgeProps> = ({ category }) => {
+  const getCategoryIcon = (category: string) => {
+    switch (category) {
+      case 'home':
+        return (
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+            <path d="M10 20V10H5v10H0V10L10 0l10 10v10h-5V10h-5v10z" />
+          </svg>
+        );
+      case 'hobbies':
+        return (
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+            <path d="M10 0C4.48 0 0 4.48 0 10s4.48 10 10 10 10-4.48 10-10S15.52 0 10 0zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z" />
+          </svg>
+        );
+      case 'work':
+        return (
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+            <path d="M10 0C4.48 0 0 4.48 0 10s4.48 10 10 10 10-4.48 10-10S15.52 0 10 0zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z" />
+          </svg>
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <span className={`category-badge ${category}`}>
+      {getCategoryIcon(category)}
+      {category}
+    </span>
+  );
+};
+
+export default CategoryBadge;

--- a/app/components/CategoryDropdown.tsx
+++ b/app/components/CategoryDropdown.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+type CategoryDropdownProps = {
+  selectedCategory: 'home' | 'hobbies' | 'work';
+  onSelectCategory: (category: 'home' | 'hobbies' | 'work') => void;
+};
+
+const CategoryDropdown: React.FC<CategoryDropdownProps> = ({ selectedCategory, onSelectCategory }) => {
+  return (
+    <select
+      value={selectedCategory}
+      onChange={(e) => onSelectCategory(e.target.value as 'home' | 'hobbies' | 'work')}
+      className="border border-gray-200 p-3 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-400 focus:border-transparent transition-all"
+    >
+      <option value="home">Home</option>
+      <option value="hobbies">Hobbies</option>
+      <option value="work">Work</option>
+    </select>
+  );
+};
+
+export default CategoryDropdown;

--- a/app/components/__tests__/CategoryBadge.test.tsx
+++ b/app/components/__tests__/CategoryBadge.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import CategoryBadge from '../CategoryBadge';
+
+describe('CategoryBadge', () => {
+  it('renders the correct icon and text for home category', () => {
+    render(<CategoryBadge category="home" />);
+    expect(screen.getByText('home')).toBeInTheDocument();
+    expect(screen.getByRole('img', { hidden: true })).toHaveAttribute('class', 'h-5 w-5');
+  });
+
+  it('renders the correct icon and text for hobbies category', () => {
+    render(<CategoryBadge category="hobbies" />);
+    expect(screen.getByText('hobbies')).toBeInTheDocument();
+    expect(screen.getByRole('img', { hidden: true })).toHaveAttribute('class', 'h-5 w-5');
+  });
+
+  it('renders the correct icon and text for work category', () => {
+    render(<CategoryBadge category="work" />);
+    expect(screen.getByText('work')).toBeInTheDocument();
+    expect(screen.getByRole('img', { hidden: true })).toHaveAttribute('class', 'h-5 w-5');
+  });
+});

--- a/app/components/__tests__/CategoryDropdown.test.tsx
+++ b/app/components/__tests__/CategoryDropdown.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import CategoryDropdown from '../CategoryDropdown';
+
+describe('CategoryDropdown', () => {
+  it('renders the dropdown with the correct default value', () => {
+    render(<CategoryDropdown selectedCategory="home" onSelectCategory={() => {}} />);
+    expect(screen.getByDisplayValue('Home')).toBeInTheDocument();
+  });
+
+  it('calls onSelectCategory with the correct value when a new category is selected', () => {
+    const mockOnSelectCategory = jest.fn();
+    render(<CategoryDropdown selectedCategory="home" onSelectCategory={mockOnSelectCategory} />);
+    fireEvent.change(screen.getByDisplayValue('Home'), { target: { value: 'work' } });
+    expect(mockOnSelectCategory).toHaveBeenCalledWith('work');
+  });
+
+  it('renders all category options', () => {
+    render(<CategoryDropdown selectedCategory="home" onSelectCategory={() => {}} />);
+    expect(screen.getByDisplayValue('Home')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Hobbies')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Work')).toBeInTheDocument();
+  });
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -24,3 +24,34 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* Category Badge Styles */
+.category-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.category-badge.home {
+  background-color: #f0f4c3;
+  color: #827717;
+}
+
+.category-badge.hobbies {
+  background-color: #ffe0b2;
+  color: #e65100;
+}
+
+.category-badge.work {
+  background-color: #bbdefb;
+  color: #0d47a1;
+}
+
+.category-badge svg {
+  margin-right: 0.25rem;
+  width: 1rem;
+  height: 1rem;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import CategoryDropdown from "./components/CategoryDropdown";
+import CategoryBadge from "./components/CategoryBadge";
 
 export default function Home() {
   const [todo, setTodo] = useState("");
-  const [todoList, setTodoList] = useState<string[]>([]);
+  const [category, setCategory] = useState("home");
+  const [todoList, setTodoList] = useState<{ text: string; category: string }[]>([]);
 
   useEffect(() => {
     const storedTodos = localStorage.getItem("todoList");
@@ -19,7 +22,7 @@ export default function Home() {
 
   const handleAddTodo = () => {
     if (todo.trim()) {
-      setTodoList([...todoList, todo]);
+      setTodoList([...todoList, { text: todo, category }]);
       setTodo("");
     }
   };
@@ -43,6 +46,7 @@ export default function Home() {
               placeholder="What needs to be done?"
               onKeyDown={(e) => e.key === "Enter" && handleAddTodo()}
             />
+            <CategoryDropdown selectedCategory={category} onSelectCategory={setCategory} />
             <button 
               onClick={handleAddTodo} 
               className="bg-blue-500 text-white p-3 rounded-lg shadow-md hover:bg-blue-600 transition-colors duration-200 flex items-center justify-center"
@@ -60,7 +64,10 @@ export default function Home() {
           ) : (
             todoList.map((item, index) => (
               <li key={index} className="bg-white p-4 rounded-xl shadow-md flex justify-between items-center group hover:shadow-lg transition-shadow duration-200">
-                <span className="text-gray-700">{item}</span>
+                <div className="flex items-center gap-2">
+                  <CategoryBadge category={item.category} />
+                  <span className="text-gray-700">{item.text}</span>
+                </div>
                 <button 
                   onClick={() => handleRemoveTodo(index)} 
                   className="text-gray-400 hover:text-red-500 hover:bg-red-50 p-2 rounded-full transition-colors duration-200"


### PR DESCRIPTION
Related to #1

Add category selection for ToDo items.

* **UI Changes**
  * Add a dropdown menu for category selection in `app/page.tsx`.
  * Modify the ToDo list display to show the category of each item.
  * Add a badge next to each ToDo item in the list to display both the category name and an icon.
* **State Management**
  * Add a new state variable `category` to manage the selected category in `app/page.tsx`.
  * Update the `handleAddTodo` function to include the selected category in the ToDo item.
* **Styling**
  * Add styles for the category badges in `app/globals.css`, including different colors and icons for each category.
* **New Components**
  * Create `CategoryBadge` component to display the category name and icon.
  * Create `CategoryDropdown` component for the category selection dropdown menu.
* **Testing**
  * Add unit tests for `CategoryBadge` component using Jest and React Testing Library.
  * Add unit tests for `CategoryDropdown` component using Jest and React Testing Library.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jtluoto/todo-app/pull/2?shareId=9adfae61-f85e-4f1f-8b73-0ad4c5ac7658).